### PR TITLE
Persistent Headers + Handling Blank/Empty JSON Response

### DIFF
--- a/SaltyJson.py
+++ b/SaltyJson.py
@@ -1,22 +1,30 @@
 import requests
 import time
+
+
 class SaltyJson():
     def __init__(self):
         self.url = "https://www.saltybet.com/state.json"
         self.session = requests.Session()
+        self.session.headers.update({"User-Agent": "Mozilla/5.0", "Accept": "application/json"})
+        self.session.timeout = 5
 
     def get_json(self):
         try:
-            self.response = self.session.get(self.url, headers={"User-Agent": "Mozilla/5.0", "Accept":"application/json"})
+            self.response = self.session.get(self.url)
+
             if self.response.status_code != 200:
-                print(self.response.status_code)
-                print(self.response.json())
-                return self.get_json()       
+                self.get_json()
             else:
-                return self.response.json()                
+                if len(self.response.text) == 0:
+                    # blank / empty response recieved
+                    time.sleep(1)
+                    self.get_json()
+                else:
+                    return self.response.json()
         except requests.exceptions.ConnectionError:
             time.sleep(1)
-            return self.get_json()
+            self.get_json()
         except requests.exceptions.JSONDecodeError:
             time.sleep(1)
-            return self.get_json()
+            self.get_json()

--- a/SaltyParser.py
+++ b/SaltyParser.py
@@ -44,18 +44,12 @@ class SaltyJsonParser():
             return 0
 
     def is_exhib(self):
-        try:
-            if self.json_dict is not None:
-                if (self.json_dict["remaining"].split(' ')[1] == "exhibition") or (
+        if (self.json_dict["remaining"].split(' ')[1] == "exhibition") or (
                 self.json_dict["remaining"].endswith('exhibition match!')):
-                    return True
-                else:
-                    return False
-            else:
-                pass
-        except:
-            print(self.json_dict)
-            raise Exception("JSON Dict failure")
+            return True
+        else:
+            return False
+
         
         # exhib_endsin = self.json_dict["remaining"].endswith('exhibition match!')
         # if (exhib_endsin) or (exhib_split == "exhibition"):
@@ -64,17 +58,13 @@ class SaltyJsonParser():
         #     return False
     
     def is_tourney(self):
-        try:
-            if self.json_dict is not None:
-                if (self.json_dict["remaining"].rsplit(' ', 1)[-1] == "bracket!") or (
-                        self.json_dict["remaining"].split(' ')[0] == "FINAL"):
-                    return 1
-                else:
-                    return 0
+        if self.json_dict is not None:
+            if (self.json_dict["remaining"].rsplit(' ', 1)[-1] == "bracket!") or (
+                    self.json_dict["remaining"].split(' ')[0] == "FINAL"):
+                return 1
             else:
-                pass
-        except:
-            raise Exception("JSON Dict failure")
+                return 0
+
         # reverse_split = self.json_dict["remaining"].rsplit(' ', 1)[-1]
         # remaining_split = self.json_dict["remaining"].split(' ')[0]
         # if (reverse_split == "bracket!") or (remaining_split == "FINAL"):

--- a/SaltyParser.py
+++ b/SaltyParser.py
@@ -26,17 +26,17 @@ class SaltyJsonParser():
         if json_status in ['open', 'locked', '1', '2']:
             return json_status
         else:
-             webbrowser.open("https://www.saltybet.com/state.json")
-             print(f"Traditional gamestate not found.  Gamestate = {json_status}. Betting isn't open, betting isn't closed, or Player 1 or Player 2 didn't win.  Did SB break?")
-             print(json_status)
-             return json_status
+            webbrowser.open("https://www.saltybet.com/state.json")
+            print(f"Traditional gamestate not found.  Gamestate = {json_status}. Betting isn't open, betting isn't closed, or Player 1 or Player 2 didn't win.  Did SB break?")
+            print(json_status)
+            return json_status
 
     def set_p1winstatus(self):
-            if (self.get_gamestate() == "1"):
-                return 1
-            else:
-                return 0
-        
+        if (self.get_gamestate() == "1"):
+            return 1
+        else:
+            return 0
+
     def set_p2winstatus(self):
         if (self.get_gamestate() == "2"):
             return 1
@@ -45,11 +45,14 @@ class SaltyJsonParser():
 
     def is_exhib(self):
         try:
-
-            if (self.json_dict["remaining"].split(' ')[1] == "exhibition") or (self.json_dict["remaining"].endswith('exhibition match!')):
-                return True
+            if self.json_dict is not None:
+                if (self.json_dict["remaining"].split(' ')[1] == "exhibition") or (
+                self.json_dict["remaining"].endswith('exhibition match!')):
+                    return True
+                else:
+                    return False
             else:
-                return False
+                pass
         except:
             print(self.json_dict)
             raise Exception("JSON Dict failure")
@@ -61,10 +64,17 @@ class SaltyJsonParser():
         #     return False
     
     def is_tourney(self):
-        if (self.json_dict["remaining"].rsplit(' ', 1)[-1] == "bracket!") or (self.json_dict["remaining"].split(' ')[0] == "FINAL"):
-            return 1
-        else:
-            return 0
+        try:
+            if self.json_dict is not None:
+                if (self.json_dict["remaining"].rsplit(' ', 1)[-1] == "bracket!") or (
+                        self.json_dict["remaining"].split(' ')[0] == "FINAL"):
+                    return 1
+                else:
+                    return 0
+            else:
+                pass
+        except:
+            raise Exception("JSON Dict failure")
         # reverse_split = self.json_dict["remaining"].rsplit(' ', 1)[-1]
         # remaining_split = self.json_dict["remaining"].split(' ')[0]
         # if (reverse_split == "bracket!") or (remaining_split == "FINAL"):

--- a/SaltyStateMachine.py
+++ b/SaltyStateMachine.py
@@ -35,7 +35,7 @@ thread.start()
 
 while True:
     the_json = my_json.get_json()
-    if the_json is None or len(the_json) == 0:
+    if not the_json:
         print("received blank response, retrying...")
         time.sleep(1)
         the_json = my_json.get_json()

--- a/SaltyStateMachine.py
+++ b/SaltyStateMachine.py
@@ -1,4 +1,5 @@
 import os
+import time
 from SaltyJson import SaltyJson
 from SaltyParser import SaltyJsonParser
 from SaltyDatabase import SaltyDatabase
@@ -34,96 +35,101 @@ thread.start()
 
 while True:
     the_json = my_json.get_json()
-    my_parser = SaltyJsonParser(the_json)
-    game_mode = my_parser.get_gameMode()
-    game_state = my_parser.get_gamestate()
+    if the_json is None or len(the_json) == 0:
+        print("received blank response, retrying...")
+        time.sleep(1)
+        the_json = my_json.get_json()
+    else:
+        my_parser = SaltyJsonParser(the_json)
+        game_mode = my_parser.get_gameMode()
+        game_state = my_parser.get_gamestate()
 
 
-    #if (game_mode != previous_game_mode) and (game_state == previous_game_state):
-    #exitiing_mode == True
-    if (game_mode != previous_game_mode):
-        game_state_lies = True
-        print(game_state_lies)
-    previous_game_mode = game_mode
-    
-    if (game_state != previous_game_state):
-        game_state_lies = False
-    previous_game_state = game_state
-    
-    
-    if ((game_mode != 'Exhibition') and (game_state_lies is False)):
-        exiting_tourney = True
-        if (game_state == 'open'):
-            if (new_match == 0):
-                os.system('cls')
-                bettor.set_balance(interactor.get_balance())
-                first_run = False
-                p1name = my_parser.get_p1name()
-                p2name = my_parser.get_p2name()
-                p1DB_ratings = bettor.set_player_rating(database.get_ratings_from_DB(p1name)) # Gets Mu and Sigma for Player 1 in DB, sets them to default if there are no prior matches in the DB, and sets them accordingly if there are.
-                p2DB_ratings = bettor.set_player_rating(database.get_ratings_from_DB(p2name)) # Gets Mu and Sigma for Player 2 in DB, sets them to default if there are no prior matches in the DB, and sets them accordingly if there are.
-                p1DB_streak = database.get_winstreaks_from_DB(p1name)
-                p2DB_streak = database.get_winstreaks_from_DB(p2name)
-                p1_probability = bettor.probability_of_p1_win(p1DB_ratings.mu, p1DB_ratings.sigma, p2DB_ratings.mu, p2DB_ratings.sigma)
-                predicted_winner = bettor.predicted_winner(p1DB_ratings.sigma, p2DB_ratings.sigma, p1_probability, p1name, p2name, p1DB_streak, p2DB_streak)
-                kelly_bet = bettor.kelly_bet(p1_probability, bettor.balance, predicted_winner, game_mode)
-                my_parser.gameMode_printer(p1DB_ratings, p2DB_ratings, p1DB_streak, p2DB_streak, p1_probability, bettor.balance)
-                bettor.bet_outcome_amount(game_state_lies)
-                interactor.place_bet_on_website(bettor.format_bet(predicted_winner, kelly_bet))
-                new_match = 1
-                my_socket.find_winstreak = True            
-        elif (game_state == 'locked'):
-            if (first_run is False):
+        #if (game_mode != previous_game_mode) and (game_state == previous_game_state):
+        #exitiing_mode == True
+        if (game_mode != previous_game_mode):
+            game_state_lies = True
+            print(game_state_lies)
+        previous_game_mode = game_mode
+
+        if (game_state != previous_game_state):
+            game_state_lies = False
+        previous_game_state = game_state
+
+
+        if ((game_mode != 'Exhibition') and (game_state_lies is False)):
+            exiting_tourney = True
+            if (game_state == 'open'):
+                if (new_match == 0):
+                    os.system('cls')
+                    bettor.set_balance(interactor.get_balance())
+                    first_run = False
+                    p1name = my_parser.get_p1name()
+                    p2name = my_parser.get_p2name()
+                    p1DB_ratings = bettor.set_player_rating(database.get_ratings_from_DB(p1name)) # Gets Mu and Sigma for Player 1 in DB, sets them to default if there are no prior matches in the DB, and sets them accordingly if there are.
+                    p2DB_ratings = bettor.set_player_rating(database.get_ratings_from_DB(p2name)) # Gets Mu and Sigma for Player 2 in DB, sets them to default if there are no prior matches in the DB, and sets them accordingly if there are.
+                    p1DB_streak = database.get_winstreaks_from_DB(p1name)
+                    p2DB_streak = database.get_winstreaks_from_DB(p2name)
+                    p1_probability = bettor.probability_of_p1_win(p1DB_ratings.mu, p1DB_ratings.sigma, p2DB_ratings.mu, p2DB_ratings.sigma)
+                    predicted_winner = bettor.predicted_winner(p1DB_ratings.sigma, p2DB_ratings.sigma, p1_probability, p1name, p2name, p1DB_streak, p2DB_streak)
+                    kelly_bet = bettor.kelly_bet(p1_probability, bettor.balance, predicted_winner, game_mode)
+                    my_parser.gameMode_printer(p1DB_ratings, p2DB_ratings, p1DB_streak, p2DB_streak, p1_probability, bettor.balance)
+                    bettor.bet_outcome_amount(game_state_lies)
+                    interactor.place_bet_on_website(bettor.format_bet(predicted_winner, kelly_bet))
+                    new_match = 1
+                    my_socket.find_winstreak = True
+            elif (game_state == 'locked'):
+                if (first_run is False):
+                    if (new_match == 1):
+                        game_time.timer_start()
+                        p1_odds = my_parser.get_p1odds()
+                        p2_odds = my_parser.get_p2odds()
+                        print(f"Odds are: ({p1_odds} : {p2_odds})")
+                        my_parser.gameMode_printer(p1DB_ratings, p2DB_ratings, p1DB_streak, p2DB_streak, p1_probability, bettor.balance)
+                        new_match = 2
+            elif (game_state == '1') or (game_state == '2'):
+                if (first_run is False):
+                    if (new_match == 2):
+                        p1_win_status = my_parser.set_p1winstatus()
+                        p2_win_status = my_parser.set_p2winstatus()
+                        is_tourney = my_parser.is_tourney()
+                        game_time.timer_snapshot()
+                        my_parser.gameMode_printer(p1DB_ratings, p2DB_ratings, p1DB_streak, p2DB_streak, p1_probability, bettor.balance)
+                        ratings_to_db = bettor.update_ranking_after(game_state, p1DB_ratings, p2DB_ratings)
+                        my_socket.adjust_winstreak(p1_win_status, p2_win_status, thread.true_p1_streak, thread.true_p2_streak)
+                        my_socket.adjust_tier(thread.true_tier)
+                        bettor.bet_outcome(p1name, p2name, game_state)
+                        database.record_match(p1name,p1_odds, p1_win_status, p2name, p2_odds, p2_win_status, my_socket.adj_p1winstreak, my_socket.adj_p2winstreak, my_socket.adj_p1_tier, my_socket.adj_p2_tier, ratings_to_db[0].mu, ratings_to_db[0].sigma, ratings_to_db[1].mu, ratings_to_db[1].sigma, game_time.snapshot, bettor.outcome, is_tourney)
+                        panda.panda_to_csv(database.db_for_pandas())
+                        new_match = 0
+
+
+        elif ((game_mode == 'Matchmaking') and (game_state_lies is True)):
+            game_state_lies = False
+            new_match = 0
+
+        elif ((game_mode == "Exhibition") and (game_state_lies is False)):
+            if (game_state == "open"):
+                if (new_match == 0):
+                    os.system('cls')
+                    print(f"In Exhibition.  No bets are placed, and nothing is recorded.  {my_parser.get_matches_remaining()} matches left.")
+                    new_match = 1
+            elif (game_state == "locked"):
                 if (new_match == 1):
-                    game_time.timer_start()
-                    p1_odds = my_parser.get_p1odds()
-                    p2_odds = my_parser.get_p2odds()
-                    print(f"Odds are: ({p1_odds} : {p2_odds})")
-                    my_parser.gameMode_printer(p1DB_ratings, p2DB_ratings, p1DB_streak, p2DB_streak, p1_probability, bettor.balance)
+                    print(f"In Exhibition.  No bets are placed, and nothing is recorded.  {my_parser.get_matches_remaining()} matches left.")
                     new_match = 2
-        elif (game_state == '1') or (game_state == '2'): 
-            if (first_run is False):
-                if (new_match == 2):            
-                    p1_win_status = my_parser.set_p1winstatus()
-                    p2_win_status = my_parser.set_p2winstatus()
-                    is_tourney = my_parser.is_tourney()
-                    game_time.timer_snapshot()
-                    my_parser.gameMode_printer(p1DB_ratings, p2DB_ratings, p1DB_streak, p2DB_streak, p1_probability, bettor.balance)
-                    ratings_to_db = bettor.update_ranking_after(game_state, p1DB_ratings, p2DB_ratings)
-                    my_socket.adjust_winstreak(p1_win_status, p2_win_status, thread.true_p1_streak, thread.true_p2_streak)
-                    my_socket.adjust_tier(thread.true_tier)
-                    bettor.bet_outcome(p1name, p2name, game_state)
-                    database.record_match(p1name,p1_odds, p1_win_status, p2name, p2_odds, p2_win_status, my_socket.adj_p1winstreak, my_socket.adj_p2winstreak, my_socket.adj_p1_tier, my_socket.adj_p2_tier, ratings_to_db[0].mu, ratings_to_db[0].sigma, ratings_to_db[1].mu, ratings_to_db[1].sigma, game_time.snapshot, bettor.outcome, is_tourney)                    
-                    panda.panda_to_csv(database.db_for_pandas())
+            elif (game_state == "1") or (game_state == "2"):
+                if (new_match == 2):
+                    if exiting_tourney == True:
+                        database.record_match(p1name,p1_odds, p1_win_status, p2name, p2_odds, p2_win_status, my_socket.adj_p1winstreak, my_socket.adj_p2winstreak, my_socket.adj_p1_tier, my_socket.adj_p2_tier, ratings_to_db[0].mu, ratings_to_db[0].sigma, ratings_to_db[1].mu, ratings_to_db[1].sigma, game_time.snapshot, bettor.outcome, 1)
+                        game_state_lies = False
+                        exiting_tourney = False
+                    print(f"In Exhibition.  No bets are placed, and nothing is recorded.  {my_parser.get_matches_remaining()} matches left.")
                     new_match = 0
-    
-    
-    elif ((game_mode == 'Matchmaking') and (game_state_lies is True)):
-        game_state_lies = False
-        new_match = 0
-    
-    elif ((game_mode == "Exhibition") and (game_state_lies is False)):
-        if (game_state == "open"):
-            if (new_match == 0):
-                os.system('cls')
-                print(f"In Exhibition.  No bets are placed, and nothing is recorded.  {my_parser.get_matches_remaining()} matches left.")
-                new_match = 1
-        elif (game_state == "locked"):
-            if (new_match == 1):
-                print(f"In Exhibition.  No bets are placed, and nothing is recorded.  {my_parser.get_matches_remaining()} matches left.")
-                new_match = 2
-        elif (game_state == "1") or (game_state == "2"):
-            if (new_match == 2):
-                if exiting_tourney == True:
-                    database.record_match(p1name,p1_odds, p1_win_status, p2name, p2_odds, p2_win_status, my_socket.adj_p1winstreak, my_socket.adj_p2winstreak, my_socket.adj_p1_tier, my_socket.adj_p2_tier, ratings_to_db[0].mu, ratings_to_db[0].sigma, ratings_to_db[1].mu, ratings_to_db[1].sigma, game_time.snapshot, bettor.outcome, 1)
-                    game_state_lies = False
-                    exiting_tourney = False
-                print(f"In Exhibition.  No bets are placed, and nothing is recorded.  {my_parser.get_matches_remaining()} matches left.")
-                new_match = 0
-    elif ((game_mode == "Exhibition") and (game_state_lies is True)):
-        database.record_match(p1name,p1_odds, p1_win_status, p2name, p2_odds, p2_win_status, my_socket.adj_p1winstreak, my_socket.adj_p2winstreak, my_socket.adj_p1_tier, my_socket.adj_p2_tier, ratings_to_db[0].mu, ratings_to_db[0].sigma, ratings_to_db[1].mu, ratings_to_db[1].sigma, game_time.snapshot, bettor.outcome, 1)
-        game_state_lies = False
-        new_match = 0
+        elif ((game_mode == "Exhibition") and (game_state_lies is True)):
+            database.record_match(p1name,p1_odds, p1_win_status, p2name, p2_odds, p2_win_status, my_socket.adj_p1winstreak, my_socket.adj_p2winstreak, my_socket.adj_p1_tier, my_socket.adj_p2_tier, ratings_to_db[0].mu, ratings_to_db[0].sigma, ratings_to_db[1].mu, ratings_to_db[1].sigma, game_time.snapshot, bettor.outcome, 1)
+            game_state_lies = False
+            new_match = 0
 
 
 


### PR DESCRIPTION
This PR fixes #16 and should mitigate #5.

1. Two additions to SaltyJson.py: `self.session.headers.update({"User-Agent": "Mozilla/5.0", "Accept": "application/json"})` is used to have headers stay persistent in the session. As recommended by the requests docs, I also added a 5 second request timeout, `self.session.timeout = 5`. Without this, the session could theoretically block indefinitely while waiting for a response to return.
2. One addition to SaltyStateMachine.py: Checking `if not the_json:`, instead of blindly accepting whatever get_json() returns, before proceeding with the rest of the code. If the server returned an empty or otherwise 'falsey' response, this should handle it by retrying it after one second. 

See log of this successfully preventing the program from breaking:
```
Currently in Matchmaking with 72 matches remaining.  Game state is locked.
True Streaks are: (-3, 1)
>> received blank response, retrying... <<
Currently in Matchmaking with 71 matches remaining.  Game state is 2.
Player 2 wins!
YOU WON THE BET!
This match has been added to the DB. There are now 3819 records in the database.
Login success!
Currently in Matchmaking with 71 matches remaining.  Game state is open.
+-----------+---------+-------------+----------+
|  Fighter  |   Skill |   Variation |   Streak |
+===========+=========+=============+==========+
| Player 1: | 31.9572 |     6.46387 |        1 |
+-----------+---------+-------------+----------+
| Player 2: | 29.3958 |     7.17148 |        1 |
+-----------+---------+-------------+----------+
```

I'm not sure why all the checks we have in the SaltyJson.get_json() fail to stop the blank response from occurring, but at the very least, it seems that adding a check to SaltyStateMachine fixes this. Now that our headers are correct, I am more confident that the server is genuinely returning a blank/empty response on occasion, and my hope is that we can just use this check to prevent this from being an issue in the future. 