### PR TITLE
Handling blank/empty response returned from get_json

### DIFF
--- a/SaltyJson.py
+++ b/SaltyJson.py
@@ -9,7 +9,6 @@ class SaltyJson():
         self.session.headers.update({
             "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/111.0.0.0 Safari/537.36",
             "Accept": "application/json"})
-        self.session.timeout = 5
 
     def get_json(self):
         try:

--- a/SaltyJson.py
+++ b/SaltyJson.py
@@ -13,12 +13,21 @@ class SaltyJson():
     def get_json(self):
         try:
             self.response = self.session.get(self.url)
+
             if self.response.status_code != 200:
-                print(self.response.status_code)
-                print(self.response.json())
+                print("status code received:", self.response.status_code)
+                time.sleep(1)
                 self.get_json()
             else:
-                return self.response.json()
+                if not self.response.text:
+                    # blank / empty response recieved
+                    print("received empty response from server, retrying...")
+                    print("response.text:", self.response.text)
+                    print("response.content:", self.response.content)
+                    time.sleep(1)
+                    self.get_json()
+                else:
+                    return self.response.json()
         except requests.exceptions.ConnectionError:
             time.sleep(1)
             self.get_json()

--- a/SaltyJson.py
+++ b/SaltyJson.py
@@ -1,22 +1,28 @@
 import requests
 import time
+
+
 class SaltyJson():
     def __init__(self):
         self.url = "https://www.saltybet.com/state.json"
         self.session = requests.Session()
+        self.session.headers.update({
+            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/111.0.0.0 Safari/537.36",
+            "Accept": "application/json"})
+        self.session.timeout = 5
 
     def get_json(self):
         try:
-            self.response = self.session.get(self.url, headers={"User-Agent": "Mozilla/5.0", "Accept":"application/json"})
+            self.response = self.session.get(self.url)
             if self.response.status_code != 200:
                 print(self.response.status_code)
                 print(self.response.json())
-                return self.get_json()       
+                self.get_json()
             else:
-                return self.response.json()                
+                return self.response.json()
         except requests.exceptions.ConnectionError:
             time.sleep(1)
-            return self.get_json()
+            self.get_json()
         except requests.exceptions.JSONDecodeError:
             time.sleep(1)
-            return self.get_json()
+            self.get_json()

--- a/SaltyParser.py
+++ b/SaltyParser.py
@@ -44,15 +44,10 @@ class SaltyJsonParser():
             return 0
 
     def is_exhib(self):
-        try:
-
-            if (self.json_dict["remaining"].split(' ')[1] == "exhibition") or (self.json_dict["remaining"].endswith('exhibition match!')):
-                return True
-            else:
-                return False
-        except:
-            print(self.json_dict)
-            raise Exception("JSON Dict failure")
+        if (self.json_dict["remaining"].split(' ')[1] == "exhibition") or (self.json_dict["remaining"].endswith('exhibition match!')):
+            return True
+        else:
+            return False
         
         # exhib_endsin = self.json_dict["remaining"].endswith('exhibition match!')
         # if (exhib_endsin) or (exhib_split == "exhibition"):

--- a/SaltyStateMachine.py
+++ b/SaltyStateMachine.py
@@ -1,4 +1,5 @@
 import os
+import time
 from SaltyJson import SaltyJson
 from SaltyParser import SaltyJsonParser
 from SaltyDatabase import SaltyDatabase
@@ -34,96 +35,100 @@ thread.start()
 
 while True:
     the_json = my_json.get_json()
-    my_parser = SaltyJsonParser(the_json)
-    game_mode = my_parser.get_gameMode()
-    game_state = my_parser.get_gamestate()
+    if not the_json:
+        print("recieved blank response, retrying...")
+        time.sleep(1)
+        continue
+    else:
+        my_parser = SaltyJsonParser(the_json)
+        game_mode = my_parser.get_gameMode()
+        game_state = my_parser.get_gamestate()
+
+        # if (game_mode != previous_game_mode) and (game_state == previous_game_state):
+        # exiting_mode == True
+        if (game_mode != previous_game_mode):
+            game_state_lies = True
+            print(game_state_lies)
+        previous_game_mode = game_mode
+
+        if (game_state != previous_game_state):
+            game_state_lies = False
+        previous_game_state = game_state
 
 
-    #if (game_mode != previous_game_mode) and (game_state == previous_game_state):
-    #exitiing_mode == True
-    if (game_mode != previous_game_mode):
-        game_state_lies = True
-        print(game_state_lies)
-    previous_game_mode = game_mode
-    
-    if (game_state != previous_game_state):
-        game_state_lies = False
-    previous_game_state = game_state
-    
-    
-    if ((game_mode != 'Exhibition') and (game_state_lies is False)):
-        exiting_tourney = True
-        if (game_state == 'open'):
-            if (new_match == 0):
-                os.system('cls')
-                bettor.set_balance(interactor.get_balance())
-                first_run = False
-                p1name = my_parser.get_p1name()
-                p2name = my_parser.get_p2name()
-                p1DB_ratings = bettor.set_player_rating(database.get_ratings_from_DB(p1name)) # Gets Mu and Sigma for Player 1 in DB, sets them to default if there are no prior matches in the DB, and sets them accordingly if there are.
-                p2DB_ratings = bettor.set_player_rating(database.get_ratings_from_DB(p2name)) # Gets Mu and Sigma for Player 2 in DB, sets them to default if there are no prior matches in the DB, and sets them accordingly if there are.
-                p1DB_streak = database.get_winstreaks_from_DB(p1name)
-                p2DB_streak = database.get_winstreaks_from_DB(p2name)
-                p1_probability = bettor.probability_of_p1_win(p1DB_ratings.mu, p1DB_ratings.sigma, p2DB_ratings.mu, p2DB_ratings.sigma)
-                predicted_winner = bettor.predicted_winner(p1DB_ratings.sigma, p2DB_ratings.sigma, p1_probability, p1name, p2name, p1DB_streak, p2DB_streak)
-                kelly_bet = bettor.kelly_bet(p1_probability, bettor.balance, predicted_winner, game_mode)
-                my_parser.gameMode_printer(p1DB_ratings, p2DB_ratings, p1DB_streak, p2DB_streak, p1_probability, bettor.balance)
-                bettor.bet_outcome_amount(game_state_lies)
-                interactor.place_bet_on_website(bettor.format_bet(predicted_winner, kelly_bet))
-                new_match = 1
-                my_socket.find_winstreak = True            
-        elif (game_state == 'locked'):
-            if (first_run is False):
+        if ((game_mode != 'Exhibition') and (game_state_lies is False)):
+            exiting_tourney = True
+            if (game_state == 'open'):
+                if (new_match == 0):
+                    os.system('cls')
+                    bettor.set_balance(interactor.get_balance())
+                    first_run = False
+                    p1name = my_parser.get_p1name()
+                    p2name = my_parser.get_p2name()
+                    p1DB_ratings = bettor.set_player_rating(database.get_ratings_from_DB(p1name)) # Gets Mu and Sigma for Player 1 in DB, sets them to default if there are no prior matches in the DB, and sets them accordingly if there are.
+                    p2DB_ratings = bettor.set_player_rating(database.get_ratings_from_DB(p2name)) # Gets Mu and Sigma for Player 2 in DB, sets them to default if there are no prior matches in the DB, and sets them accordingly if there are.
+                    p1DB_streak = database.get_winstreaks_from_DB(p1name)
+                    p2DB_streak = database.get_winstreaks_from_DB(p2name)
+                    p1_probability = bettor.probability_of_p1_win(p1DB_ratings.mu, p1DB_ratings.sigma, p2DB_ratings.mu, p2DB_ratings.sigma)
+                    predicted_winner = bettor.predicted_winner(p1DB_ratings.sigma, p2DB_ratings.sigma, p1_probability, p1name, p2name, p1DB_streak, p2DB_streak)
+                    kelly_bet = bettor.kelly_bet(p1_probability, bettor.balance, predicted_winner, game_mode)
+                    my_parser.gameMode_printer(p1DB_ratings, p2DB_ratings, p1DB_streak, p2DB_streak, p1_probability, bettor.balance)
+                    bettor.bet_outcome_amount(game_state_lies)
+                    interactor.place_bet_on_website(bettor.format_bet(predicted_winner, kelly_bet))
+                    new_match = 1
+                    my_socket.find_winstreak = True
+            elif (game_state == 'locked'):
+                if (first_run is False):
+                    if (new_match == 1):
+                        game_time.timer_start()
+                        p1_odds = my_parser.get_p1odds()
+                        p2_odds = my_parser.get_p2odds()
+                        print(f"Odds are: ({p1_odds} : {p2_odds})")
+                        my_parser.gameMode_printer(p1DB_ratings, p2DB_ratings, p1DB_streak, p2DB_streak, p1_probability, bettor.balance)
+                        new_match = 2
+            elif (game_state == '1') or (game_state == '2'):
+                if (first_run is False):
+                    if (new_match == 2):
+                        p1_win_status = my_parser.set_p1winstatus()
+                        p2_win_status = my_parser.set_p2winstatus()
+                        is_tourney = my_parser.is_tourney()
+                        game_time.timer_snapshot()
+                        my_parser.gameMode_printer(p1DB_ratings, p2DB_ratings, p1DB_streak, p2DB_streak, p1_probability, bettor.balance)
+                        ratings_to_db = bettor.update_ranking_after(game_state, p1DB_ratings, p2DB_ratings)
+                        my_socket.adjust_winstreak(p1_win_status, p2_win_status, thread.true_p1_streak, thread.true_p2_streak)
+                        my_socket.adjust_tier(thread.true_tier)
+                        bettor.bet_outcome(p1name, p2name, game_state)
+                        database.record_match(p1name,p1_odds, p1_win_status, p2name, p2_odds, p2_win_status, my_socket.adj_p1winstreak, my_socket.adj_p2winstreak, my_socket.adj_p1_tier, my_socket.adj_p2_tier, ratings_to_db[0].mu, ratings_to_db[0].sigma, ratings_to_db[1].mu, ratings_to_db[1].sigma, game_time.snapshot, bettor.outcome, is_tourney)
+                        panda.panda_to_csv(database.db_for_pandas())
+                        new_match = 0
+
+
+        elif ((game_mode == 'Matchmaking') and (game_state_lies is True)):
+            game_state_lies = False
+            new_match = 0
+
+        elif ((game_mode == "Exhibition") and (game_state_lies is False)):
+            if (game_state == "open"):
+                if (new_match == 0):
+                    os.system('cls')
+                    print(f"In Exhibition.  No bets are placed, and nothing is recorded.  {my_parser.get_matches_remaining()} matches left.")
+                    new_match = 1
+            elif (game_state == "locked"):
                 if (new_match == 1):
-                    game_time.timer_start()
-                    p1_odds = my_parser.get_p1odds()
-                    p2_odds = my_parser.get_p2odds()
-                    print(f"Odds are: ({p1_odds} : {p2_odds})")
-                    my_parser.gameMode_printer(p1DB_ratings, p2DB_ratings, p1DB_streak, p2DB_streak, p1_probability, bettor.balance)
+                    print(f"In Exhibition.  No bets are placed, and nothing is recorded.  {my_parser.get_matches_remaining()} matches left.")
                     new_match = 2
-        elif (game_state == '1') or (game_state == '2'): 
-            if (first_run is False):
-                if (new_match == 2):            
-                    p1_win_status = my_parser.set_p1winstatus()
-                    p2_win_status = my_parser.set_p2winstatus()
-                    is_tourney = my_parser.is_tourney()
-                    game_time.timer_snapshot()
-                    my_parser.gameMode_printer(p1DB_ratings, p2DB_ratings, p1DB_streak, p2DB_streak, p1_probability, bettor.balance)
-                    ratings_to_db = bettor.update_ranking_after(game_state, p1DB_ratings, p2DB_ratings)
-                    my_socket.adjust_winstreak(p1_win_status, p2_win_status, thread.true_p1_streak, thread.true_p2_streak)
-                    my_socket.adjust_tier(thread.true_tier)
-                    bettor.bet_outcome(p1name, p2name, game_state)
-                    database.record_match(p1name,p1_odds, p1_win_status, p2name, p2_odds, p2_win_status, my_socket.adj_p1winstreak, my_socket.adj_p2winstreak, my_socket.adj_p1_tier, my_socket.adj_p2_tier, ratings_to_db[0].mu, ratings_to_db[0].sigma, ratings_to_db[1].mu, ratings_to_db[1].sigma, game_time.snapshot, bettor.outcome, is_tourney)                    
-                    panda.panda_to_csv(database.db_for_pandas())
+            elif (game_state == "1") or (game_state == "2"):
+                if (new_match == 2):
+                    if exiting_tourney == True:
+                        database.record_match(p1name,p1_odds, p1_win_status, p2name, p2_odds, p2_win_status, my_socket.adj_p1winstreak, my_socket.adj_p2winstreak, my_socket.adj_p1_tier, my_socket.adj_p2_tier, ratings_to_db[0].mu, ratings_to_db[0].sigma, ratings_to_db[1].mu, ratings_to_db[1].sigma, game_time.snapshot, bettor.outcome, 1)
+                        game_state_lies = False
+                        exiting_tourney = False
+                    print(f"In Exhibition.  No bets are placed, and nothing is recorded.  {my_parser.get_matches_remaining()} matches left.")
                     new_match = 0
-    
-    
-    elif ((game_mode == 'Matchmaking') and (game_state_lies is True)):
-        game_state_lies = False
-        new_match = 0
-    
-    elif ((game_mode == "Exhibition") and (game_state_lies is False)):
-        if (game_state == "open"):
-            if (new_match == 0):
-                os.system('cls')
-                print(f"In Exhibition.  No bets are placed, and nothing is recorded.  {my_parser.get_matches_remaining()} matches left.")
-                new_match = 1
-        elif (game_state == "locked"):
-            if (new_match == 1):
-                print(f"In Exhibition.  No bets are placed, and nothing is recorded.  {my_parser.get_matches_remaining()} matches left.")
-                new_match = 2
-        elif (game_state == "1") or (game_state == "2"):
-            if (new_match == 2):
-                if exiting_tourney == True:
-                    database.record_match(p1name,p1_odds, p1_win_status, p2name, p2_odds, p2_win_status, my_socket.adj_p1winstreak, my_socket.adj_p2winstreak, my_socket.adj_p1_tier, my_socket.adj_p2_tier, ratings_to_db[0].mu, ratings_to_db[0].sigma, ratings_to_db[1].mu, ratings_to_db[1].sigma, game_time.snapshot, bettor.outcome, 1)
-                    game_state_lies = False
-                    exiting_tourney = False
-                print(f"In Exhibition.  No bets are placed, and nothing is recorded.  {my_parser.get_matches_remaining()} matches left.")
-                new_match = 0
-    elif ((game_mode == "Exhibition") and (game_state_lies is True)):
-        database.record_match(p1name,p1_odds, p1_win_status, p2name, p2_odds, p2_win_status, my_socket.adj_p1winstreak, my_socket.adj_p2winstreak, my_socket.adj_p1_tier, my_socket.adj_p2_tier, ratings_to_db[0].mu, ratings_to_db[0].sigma, ratings_to_db[1].mu, ratings_to_db[1].sigma, game_time.snapshot, bettor.outcome, 1)
-        game_state_lies = False
-        new_match = 0
+        elif ((game_mode == "Exhibition") and (game_state_lies is True)):
+            database.record_match(p1name,p1_odds, p1_win_status, p2name, p2_odds, p2_win_status, my_socket.adj_p1winstreak, my_socket.adj_p2winstreak, my_socket.adj_p1_tier, my_socket.adj_p2_tier, ratings_to_db[0].mu, ratings_to_db[0].sigma, ratings_to_db[1].mu, ratings_to_db[1].sigma, game_time.snapshot, bettor.outcome, 1)
+            game_state_lies = False
+            new_match = 0
 
 
 

--- a/SaltyStateMachine.py
+++ b/SaltyStateMachine.py
@@ -36,7 +36,8 @@ thread.start()
 while True:
     the_json = my_json.get_json()
     if not the_json:
-        print("recieved blank response, retrying...")
+        print("the_json empty or None")
+        print("received empty response from server, retrying...")
         time.sleep(1)
         continue
     else:

--- a/SaltyStateMachine.py
+++ b/SaltyStateMachine.py
@@ -1,5 +1,6 @@
 import os
 import time
+import random
 from SaltyJson import SaltyJson
 from SaltyParser import SaltyJsonParser
 from SaltyDatabase import SaltyDatabase
@@ -34,10 +35,11 @@ p2DB_streak = None
 thread.start() 
 
 while True:
+    sleep_time = 0.2 + random.uniform(0.05, 0.1)
+    time.sleep(sleep_time)
     the_json = my_json.get_json()
     if not the_json:
-        print("the_json empty or None")
-        print("received empty response from server, retrying...")
+        print("JSON returned empty or None, retrying request...")
         time.sleep(1)
         continue
     else:

--- a/SaltyStateMachine.py
+++ b/SaltyStateMachine.py
@@ -32,11 +32,13 @@ previous_game_state = None
 p1DB_streak = None
 p2DB_streak = None
 
-thread.start() 
+thread.start()
 
 while True:
+    # random sleep to reduce # of API calls made
     sleep_time = 0.2 + random.uniform(0.05, 0.1)
     time.sleep(sleep_time)
+
     the_json = my_json.get_json()
     if not the_json:
         print("JSON returned empty or None, retrying request...")
@@ -139,7 +141,7 @@ while True:
 
 # NOTE: GENERAL QUESTIONS / THINGS.
 # TODO: A way to stop the last match in a game mode earlier than have it become a super outlier for match_time:
-#       SaltyBet: Exhibitions will start shortly. Thanks for watching!        
+#       SaltyBet: Exhibitions will start shortly. Thanks for watching!
 
 
 # TODO: Traceback (most recent call last):
@@ -156,7 +158,7 @@ while True:
 #     return self.suggested_player | self.wager # Returns in the format neccessary for bet-placement on SaltyBet.com: {:} | {:}
 # AttributeError: 'SaltyBettor' object has no attribute 'suggested_player'
 
-# TODO:  
+# TODO:
 # Currently in Tournament with 2 matches remaining.  Game state is open.
 # In Exhibition.  No bets are placed, and nothing is recorded.  1 matches left.
 # Current Tier is: None


### PR DESCRIPTION
Note: This PR builds upon https://github.com/xxxFRIARxxx/SaltyBot/pull/18

This is my attempt at mitigating #5
1. Adds `if not self.response.text:` to get_json: Checks for empty response in get_json.
2. Adds `if not the_json:` to SaltyStateMachine loop. If JSON from response is falsely, i.e. None or empty, waits 1 second and repeats request to obtain JSON from get_json. All of SaltyStateMachine's code is dependent on receiving valid JSON, so this is our final check before sending it through to the rest of code. 
3. Removes try-catch from is_exhib: Should not be needed with added check to SaltyStateMachine (otherwise, we would need a try-catch for every function that deals with json_dict).
4.  Adds a random sleep to reduce calls to salty.json API. Current branch on main repo is sending ~936 requests/min to salty.json API. Although I have not seen direct evidence of rate-limiting, I think as good etiquette we should reduce the amount of requests we send to the server. My implementation reduces the amount of requests to an average of 180 per minute.

Even with headers fixed, I still have received random empty/blank response from salty.json. Assuming it has nothing to do with the website detecting scraping activity from our requests (User-Agent should prevent this), I think the server just occasionally responds with a blank response in error. Adding a few checks to make sure the response is not empty should handle that going forward.

