### PR TITLE
Handle Blank Response from Server / state.json

### DIFF
--- a/SaltyJson.py
+++ b/SaltyJson.py
@@ -11,13 +11,16 @@ class SaltyJson():
             self.response = self.session.get(self.url)
             if self.response.status_code != 200:
                 print(self.response.status_code)
-                print(self.response.json())
-                return self.get_json()       
+                self.get_json()
+            elif not self.response:
+                print("Blank response receieved, retrying...")
+                time.sleep(1)
+                self.get_json()
             else:
-                return self.response.json()                
+                return self.response.json()
         except requests.exceptions.ConnectionError:
             time.sleep(1)
-            return self.get_json()
+            self.get_json()
         except requests.exceptions.JSONDecodeError:
             time.sleep(1)
-            return self.get_json()
+            self.get_json()

--- a/SaltyJson.py
+++ b/SaltyJson.py
@@ -10,17 +10,20 @@ class SaltyJson():
         try:
             self.response = self.session.get(self.url)
             if self.response.status_code != 200:
+                print("Received non-200 status code, retrying... ")
                 print(self.response.status_code)
-                self.get_json()
-            elif not self.response:
+                time.sleep(1)
+                return self.get_json()
+            elif not self.response.text:
                 print("Blank response receieved, retrying...")
                 time.sleep(1)
-                self.get_json()
+                return self.get_json()
             else:
                 return self.response.json()
         except requests.exceptions.ConnectionError:
             time.sleep(1)
-            self.get_json()
+            return self.get_json()
         except requests.exceptions.JSONDecodeError:
+            print("Error Decoding JSON, retrying...")
             time.sleep(1)
-            self.get_json()
+            return self.get_json()


### PR DESCRIPTION
This should handle empty/blank responses from state.json. 

This can be tested with the URL: https://httpbin.org/status/200

```
import requests
import time
class SaltyJson():
    def __init__(self):
        self.url = "https://httpbin.org/status/200"
        self.session = requests.Session()
        self.session.headers.update({"User-Agent": "Mozilla/5.0", "Accept":"application/json"})

    def get_json(self):
        try:
            self.response = self.session.get(self.url)
            if self.response.status_code != 200:
                print("Received non-200 status code, retrying... ")
                print(self.response.status_code)
                time.sleep(1)
                return self.get_json()
            elif not self.response.text:
                print("Blank response received, retrying...")
                print("Headers: ", self.session.headers)
                print("Status Code: ", self.response.status_code)
                print("Non-Decoded Content: ", self.response.content)
                print("Decoded Content: ", self.response.text)
                time.sleep(1)
                return self.get_json()
            else:
                return self.response.json()
        except requests.exceptions.ConnectionError:
            time.sleep(1)
            return self.get_json()
        except requests.exceptions.JSONDecodeError:
            print("Error Decoding JSON, retrying...")
            time.sleep(1)
            return self.get_json()
```

Output:
```
Login success!
Blank response received, retrying...
Headers:  {'User-Agent': 'Mozilla/5.0', 'Accept-Encoding': 'gzip, deflate', 'Accept': 'application/json', 'Connection': 'keep-alive'}
Status Code:  200
Non-Decoded Content:  b''
Decoded Content:
Blank response received, retrying...
```