### PR TITLE
Kelly Bet Implementation/Fix

### DIFF
--- a/SaltyBettor.py
+++ b/SaltyBettor.py
@@ -154,7 +154,7 @@ class SaltyBettor():
             p = abs(p1_probability - 1)
         else:
             b = 1
-            q = 1
+            q = 0.5
             p = 0.5
 
         k_fraction = ((p * b) - q) / b

--- a/SaltyBettor.py
+++ b/SaltyBettor.py
@@ -140,23 +140,25 @@ class SaltyBettor():
 
     def kelly_bet(self, p1_probability, p1_odds_avg, p2_odds_avg, balance, predicted_winner, game_mode):
         self.suggested_wager = 1
-        q = 1-p1_probability
+
         if not all([p1_odds_avg, p2_odds_avg]):
-            b = 1
-        elif p1_odds_avg > p2_odds_avg:
-            b = p1_odds_avg
-        elif p2_odds_avg > p1_odds_avg:
-            b = p2_odds_avg
-        # elif abs(p1_odds_avg - p2_odds_avg) == 0:
-        #     b = 5
-        # elif abs(p1_odds_avg - p2_odds_avg) < 1:
-        #     b = 10
+            p1_odds_avg = 1
+            p2_odds_avg = 1
+        if p1_probability > 0.5:
+            b = 1 / p1_odds_avg
+            q = 1 - p1_probability
+            p = p1_probability
+        elif p1_probability < 0.5:
+            b = 1 / p2_odds_avg
+            q = p1_probability
+            p = abs(p1_probability - 1)
         else:
             b = 1
-        # b = 1
-        # b = p1_probability/(1-p1_probability)
-        fraction = p1_probability-(q/b)
-        k_suggest = abs(.05*(fraction*balance))
+            q = 1
+            p = 0.5
+
+        k_fraction = ((p * b) - q) / b
+        k_suggest = k_fraction*balance
         if (game_mode == "Tournament") and (self.balance < 20000):
             self.suggested_wager = self.balance
         elif (game_mode == "Matchmaking") and (self.balance < 10000):
@@ -164,7 +166,7 @@ class SaltyBettor():
         elif predicted_winner is None:
             self.suggested_wager = 1
         elif (predicted_winner != None) and (game_mode != "Tournament"):
-            if p1_probability != .5:
+            if p1_probability != .5 and k_fraction > 0:
                 self.suggested_wager = decimal.Decimal(k_suggest).quantize(decimal.Decimal('0'), rounding=decimal.ROUND_UP)          
             elif (p1_probability == .5):
                 self.suggested_wager = 1              


### PR DESCRIPTION
Resolves the following issues mentioned in https://github.com/xxxFRIARxxx/SaltyBot/issues/27
1. Removes maximum balance limit, instead relying on Kelly Bet Criterion to place bets exclusively. 
2. Removes conversion of k_fraction to an absolute value to prevent bets being placed on matches with unfavorable odds. 
3. Only uses k_suggest when k_fraction is positive value. When fraction is negative, the Kelly Bet Criterion does not recommend placing a bet on the match.